### PR TITLE
ポートフォリオのカードテンプレートを変更

### DIFF
--- a/components/organisms/portfolio/Bottom.vue
+++ b/components/organisms/portfolio/Bottom.vue
@@ -1,14 +1,8 @@
 <template>
-  <v-row dense justify="center" align-content="center">
-    <v-col cols="12">
-      <v-card>
-        <picture>
-          <source type="image/webp" srcset="/aza166.webp">
-          <img class="img" width="820" height="410" alt="自己紹介画像" src="/aza166.png">
-        </picture>
-      </v-card>
-    </v-col>
-  </v-row>
+  <picture>
+    <source type="image/webp" srcset="/aza166.webp">
+    <img class="img" width="820" height="410" alt="自己紹介画像" src="/aza166.png">
+  </picture>
 </template>
 <style scoped>
   .img {

--- a/components/organisms/portfolio/Social.vue
+++ b/components/organisms/portfolio/Social.vue
@@ -1,31 +1,23 @@
 <template>
-  <port-card-template>
-    <template slot="content">
-      <div class="center">
-        <img
-          v-for="(item, i) in social"
-          :key="i"
-          class="ico"
-          :src="convert2Path(item.img)"
-          contain
-          :height="40"
-          :width="80"
-          :alt="item.alt"
-          @click="onClick(item.url)"
-        >
-      </div>
-    </template>
-  </port-card-template>
+  <div class="center">
+    <img
+      v-for="(item, i) in social"
+      :key="i"
+      class="ico"
+      :src="convert2Path(item.img)"
+      contain
+      :height="40"
+      :width="80"
+      :alt="item.alt"
+      @click="onClick(item.url)"
+    >
+  </div>
 </template>
 
 <script>
 import social from '@/mixins/SocialMixin'
-import PortCardTemplate from '~/components/templates/portfolio/PortfolioCardTemplate.vue'
 
 export default {
-  components: {
-    'port-card-template': PortCardTemplate
-  },
   mixins: [social],
   methods: {
     convert2Path (filename) {
@@ -46,12 +38,11 @@ export default {
   justify-content: space-between;
   align-items: center;
   margin: 0 auto;
-  height: 100%;
+  height: 70px;
 }
 
 .ico{
   object-fit: fill;
   cursor: pointer;
 }
-
 </style>

--- a/components/organisms/portfolio/Tobe.vue
+++ b/components/organisms/portfolio/Tobe.vue
@@ -1,9 +1,8 @@
 <template>
-  <port-card-template title="To be...">
+  <port-card-template title="to do">
     <template slot="content">
-      <p>画面をぱっと開いた時に、なんとなく使い方がわかるような、</p>
-      <p>毎日使う時に、ストレスがないような、</p>
-      <p>そんな『日々の暮らしに馴染む』を、目指して造っています。</p>
+      <p>テクノロジーで、日々をちょっぴり快適に。</p>
+      <p>『日々の暮らしのちょっとしたストレスを軽減』を目指して、色々造っています。</p>
     </template>
   </port-card-template>
 </template>

--- a/components/organisms/portfolio/card/Product.vue
+++ b/components/organisms/portfolio/card/Product.vue
@@ -1,24 +1,5 @@
 <template>
   <div class="card">
-    <h3>
-      {{ item.name }}
-      <span class="iconsWrapper">
-        <img
-          class="img"
-          :src="convert2Path('tech-logo', item.skill[0])"
-          width="20px"
-          height="20px"
-        >
-        <a :href="item.github" target="_blank">
-          <img
-            class="img"
-            :src="convert2Path('social', 'github.svg')"
-            width="20px"
-            height="20px"
-          >
-        </a>
-      </span>
-    </h3>
     <div class="imgWrapper">
       <a :href="item.url" target="_blank">
         <img
@@ -28,6 +9,24 @@
           height="150px"
         >
       </a>
+    </div>
+    <div class="textArea">
+      <h3>
+        {{ item.name }}
+        <span class="githubIcon">
+          <a :href="item.github" target="_blank">
+            <img
+              class="img"
+              :src="convert2Path('social', 'github.svg')"
+              width="20px"
+              height="20px"
+            >
+          </a>
+        </span>
+      </h3>
+      <p>
+        {{ item.text }}
+      </p>
     </div>
   </div>
 </template>
@@ -53,27 +52,30 @@ export default {
 <style lang="scss" scoped>
 .card {
   height: auto;
-  border: 2px solid #add8e6;
+  border: 1px solid #add8e6;
   border-radius: 4px;
-  padding: 4px;
+
+.textArea {
+    margin: 0 8px;
+  }
   h3 {
     display: inline-flex;
+  }
 
-    .iconsWrapper{
-      line-height: 25px;
-      padding-top: 2px;
-      margin-left: 8px;
-    }
+  .githubIcon{
+    line-height: 25px;
+    padding-top: 2px;
+    margin-left: 8px;
   }
 
   .imgWrapper{
     text-align: center;
     .img {
-      margin-top: 8px;
-      object-fit: contain;
-      max-width: 250px;
-      width: auto;
-      max-height: 150px;
+      margin-bottom: 8px;
+      border-radius: 4px 4px 0 0;
+      object-fit: cover;
+      width: 100%;
+      height: auto;
     }
   }
 }

--- a/components/templates/portfolio/PortfolioCardTemplate.vue
+++ b/components/templates/portfolio/PortfolioCardTemplate.vue
@@ -1,16 +1,10 @@
 <template>
-  <v-row dense justify="center" align-content="center">
-    <v-col cols="12">
-      <v-card>
-        <v-card-title v-if="title">
-          {{ title }}
-        </v-card-title>
-        <v-card-text>
-          <slot name="content" />
-        </v-card-text>
-      </v-card>
-    </v-col>
-  </v-row>
+  <div class="cardTemplate">
+    <h1 v-if="title">
+      ■ {{ title }}
+    </h1>
+    <slot name="content" />
+  </div>
 </template>
 
 <script>
@@ -25,8 +19,11 @@ export default {
 }
 </script>
 
-<style>
-.card-template{
-  min-height: 350px;
+<style lang="scss" scoped>
+.cardTemplate{
+  h1 {
+    margin-bottom: 8px;
+  }
 }
+
 </style>

--- a/mixins/ProductsMixin.js
+++ b/mixins/ProductsMixin.js
@@ -4,21 +4,21 @@ const _products = [
     img: 'portfolio.png',
     url: 'https://manasas.dev/',
     github: 'https://github.com/thetalemon/manasandbox',
-    skill: ['vuejs.svg']
+    text: 'このサイト。Nuxt.js製。'
   },
   {
     name: 'ブログ',
     img: 'blog.png',
     url: 'https://blog.manasas.dev/',
     github: 'https://github.com/thetalemon/manasblog',
-    skill: ['react.svg']
+    text: 'Next.js + microCMS。'
   },
   {
     name: 'あいきゃっちじぇねれーた',
     img: 'eyecatch.png',
     url: 'https://eyecatch.manasas.dev/',
     github: 'https://github.com/thetalemon/eye-catch-creator',
-    skill: ['react.svg']
+    text: '記事投稿する時のアイキャッチ作るやつ。Next.js + HTML5のcanvas機能。'
   }
 ]
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -3,12 +3,13 @@
     <div class="main-container">
       <portTop />
       <portSocial />
-      <portTobe />
-      <portProd />
-      <portSkill />
-      <portCert />
-      <portTimeline />
-      <!-- <portInterests /> -->
+      <div class="mainContents">
+        <portTobe class="component" />
+        <portProd class="component" />
+        <portSkill class="component" />
+        <portCert class="component" />
+        <portTimeline class="component" />
+      </div>
       <portSocial />
       <portBottom />
     </div>
@@ -49,5 +50,16 @@ export default {
   min-width: 320px;
   padding: 0 10px 10px 10px;
   margin: 0 auto;
+  .mainContents {
+    .component{
+      padding-top: 40px;
+      border-top: 1px #add8e6 solid;
+      margin-bottom: 40px;
+
+      &:first-of-type{
+        border-top: none;
+      }
+    }
+  }
 }
 </style>


### PR DESCRIPTION
# 概要
- ポートフォリオのカードのテンプレートを変更してサッパリした印象にしました

# before/after
- びふぉー


![manasas dev_ (1)](https://user-images.githubusercontent.com/47911711/137763507-22ab44fa-4fd7-4a93-9d87-5f8622bafda1.png)

- あふたー

![localhost_3000_ (2)](https://user-images.githubusercontent.com/47911711/137763187-7b9dd61c-ee19-4543-b26a-a8e3b3ada1d8.png)